### PR TITLE
Move export block after includes to avoid Julia 1.12+ world-age warnings

### DIFF
--- a/src/FastTanhSinhQuadrature.jl
+++ b/src/FastTanhSinhQuadrature.jl
@@ -20,12 +20,6 @@ using StaticArrays
 using LambertW
 using LoopVectorization
 
-export tanhsinh, quad, quad_split, quad_cmpl,
-    integrate1D, integrate2D, integrate3D,
-    integrate1D_avx, integrate2D_avx, integrate3D_avx,
-    adaptive_integrate_1D, adaptive_integrate_2D, adaptive_integrate_3D,
-    adaptive_integrate_1D_cmpl
-
 # Core transformation functions and node generation
 include("core.jl")
 
@@ -43,5 +37,11 @@ include("adaptive.jl")
 
 # High-level quad interface
 include("quad.jl")
+
+export tanhsinh, quad, quad_split, quad_cmpl,
+    integrate1D, integrate2D, integrate3D,
+    integrate1D_avx, integrate2D_avx, integrate3D_avx,
+    adaptive_integrate_1D, adaptive_integrate_2D, adaptive_integrate_3D,
+    adaptive_integrate_1D_cmpl
 
 end


### PR DESCRIPTION
This PR fixes Julia 1.12+ world-age warnings seen during `using FastTanhSinhQuadrature` and precompilation.

Root cause: exported bindings were accessed before all included files finished defining methods.

Fix: moved the module export block to the end of src/FastTanhSinhQuadrature.jl, after all include(...) statements.

Behavior/API: no functional change; only module load order/initialization cleanup.
Validation:
```
julia --project=. --depwarn=error -e 'using FastTanhSinhQuadrature' 
```
now loads cleanly without world-age warnings.