### PR TITLE
Fix quad_cmpl complementary coordinate handling and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ println(val)  # ≈ 4.0
 
 ### High-Accuracy Interface: `quad_cmpl`
 
-For functions extremely sensitive near endpoints (e.g., $1-x$ or $1+x$), use `quad_cmpl`. The function `f` should accept three arguments: `f(x, 1-x, 1+x)`.
+For functions extremely sensitive near endpoints (e.g., $1-x$ or $1+x$), use `quad_cmpl`.
+The function `f` should accept three arguments: `f(x, b-x, x-a)` for interval `[a, b]`.
+For `[-1, 1]`, this is `f(x, 1-x, 1+x)`.
 
 ```julia
 using FastTanhSinhQuadrature
@@ -161,7 +163,7 @@ println(val)  # ≈ 1.0
 |----------|-------------|
 | `quad(f; tol, max_levels)` | Adaptive 1D integration over `[-1, 1]` |
 | `quad(f, low, up; tol, max_levels)` | Adaptive 1D integration over `[low, up]` |
-| `quad_cmpl(f, low, up; ...)` | High-accuracy 1D integration for `f(x, 1-x, 1+x)` |
+| `quad_cmpl(f, low, up; ...)` | High-accuracy 1D integration for `f(x, b-x, x-a)` |
 | `quad(f, low, up; ...)` | Adaptive 2D/3D integration (accepts `SVector` bounds) |
 | `quad_split(f, c; ...)` | Split domain `[-1, 1]` at singularity `c` and integrate |
 | `quad_split(f, c, low, up; ...)` | Split domain `[low, up]` at singularity `c` and integrate |

--- a/src/adaptive.jl
+++ b/src/adaptive.jl
@@ -290,8 +290,8 @@ end
     adaptive_integrate_1D_cmpl(::Type{T}, f::Function, a, b; tol::Real=1e-12, max_levels::Int=10)
 
 Adaptive 1D Tanh-Sinh integration for functions sensitive near endpoints.
-`f` should accept three arguments: `f(x, 1-x, 1+x)` for the interval `[-1, 1]`.
-For general `[a, b]`, the arguments are `f(x, (b-x)/(b-a), (x-a)/(b-a))`.
+`f` should accept three arguments: `f(x, b-x, x-a)` for the interval `[a, b]`.
+For the default interval `[-1, 1]`, this is `f(x, 1-x, 1+x)`.
 """
 function adaptive_integrate_1D_cmpl(::Type{T}, f::Function, a, b;
     tol::Real=1e-12, max_levels::Int=10) where {T<:Real}
@@ -299,20 +299,22 @@ function adaptive_integrate_1D_cmpl(::Type{T}, f::Function, a, b;
     Δx = 0.5 * (b_T - a_T)
     x₀ = 0.5 * (b_T + a_T)
 
-    tm = tmax(T)
+    # Complement coordinates remain accurate well beyond t_x_max(T),
+    # so use the weight-based window to avoid truncating endpoint tails.
+    tm = t_w_max(T, 1)
     h = tm / 2
     w0 = T(π) / 2
-    s_total = w0 * f(x₀, T(0.5), T(0.5))
+    s_total = w0 * f(x₀, Δx, Δx)
 
     for k in 1:2
         tk = k * h
         wk, xk, ck = weight(tk), ordinate(tk), ordinate_complement(tk)
-        # f(x, (b-x)/(b-a), (x-a)/(b-a))
+        # f(x, b-x, x-a)
         # At x = x₀ + Δx*xk:
-        # (b - (x₀ + Δx*xk)) / (b - a) = (Δx - Δx*xk) / (2Δx) = 0.5 * (1 - xk) = 0.5 * ck
-        # (x₀ + Δx*xk - a) / (b - a) = (Δx + Δx*xk) / (2Δx) = 0.5 * (1 + xk)
-        s_total += wk * (f(x₀ + Δx * xk, 0.5 * ck, 0.5 * (one(T) + xk)) +
-                         f(x₀ - Δx * xk, 0.5 * (one(T) + xk), 0.5 * ck))
+        # b - (x₀ + Δx*xk) = (x₀ + Δx) - (x₀ + Δx*xk) = Δx * (1 - xk) = Δx * ck
+        # (x₀ + Δx*xk) - a = (x₀ + Δx*xk) - (x₀ - Δx) = Δx * (1 + xk)
+        s_total += wk * (f(x₀ + Δx * xk, Δx * ck, Δx * (one(T) + xk)) +
+                         f(x₀ - Δx * xk, Δx * (one(T) + xk), Δx * ck))
     end
 
     old_res = Δx * h * s_total
@@ -325,8 +327,8 @@ function adaptive_integrate_1D_cmpl(::Type{T}, f::Function, a, b;
             tk = k * h
             tk > tm && break
             wk, xk, ck = weight(tk), ordinate(tk), ordinate_complement(tk)
-            s_new += wk * (f(x₀ + Δx * xk, 0.5 * ck, 0.5 * (one(T) + xk)) +
-                           f(x₀ - Δx * xk, 0.5 * (one(T) + xk), 0.5 * ck))
+            s_new += wk * (f(x₀ + Δx * xk, Δx * ck, Δx * (one(T) + xk)) +
+                           f(x₀ - Δx * xk, Δx * (one(T) + xk), Δx * ck))
             k += 2
         end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -37,9 +37,10 @@ Return 1 - |ordinate(t)| accurately. Useful for f(1-x).
 """
 @inline function ordinate_complement(t::T) where {T<:Real}
     u = (T(π) / 2) * sinh(abs(t))
-    # 1 - tanh(u) = 2 / (exp(2u) + 1)
-    # This is much more accurate than 1 - tanh(u) when tanh(u) ≈ 1.
-    return 2 / (exp(2u) + 1)
+    # 1 - tanh(u) = 2*exp(-2u) / (1 + exp(-2u))
+    # This avoids overflow in exp(2u) while preserving endpoint accuracy.
+    z = exp(-2u)
+    return 2 * z / (one(T) + z)
 end
 
 @inline function weight(t::T) where {T<:Real}
@@ -47,7 +48,7 @@ end
     # Stability: cosh can overflow for large t.
     # If the denominator cosh^2(...) would overflow, the weight is effectively 0.
     # For Float64, cosh(710) overflows.
-    if abs(arg) > T(710.0)
+    if abs(arg) > T(700.0)
         return zero(T)
     end
     tmp = cosh(arg)

--- a/src/quad.jl
+++ b/src/quad.jl
@@ -167,7 +167,8 @@ end
     quad_cmpl(f, [low, up]; tol=1e-12, max_levels=10)
 
 High-level interface for Tanh-Sinh quadrature with endpoint sensitivity.
-`f` should accept three arguments: `f(x, 1-x, 1+x)`.
+`f` should accept three arguments: `f(x, b-x, x-a)` for interval `[a, b]`.
+For `[-1, 1]`, this is `f(x, 1-x, 1+x)`.
 """
 function quad_cmpl(f::Function, low::T, up::T; tol::Real=1e-12, max_levels::Int=10) where {T<:Real}
     if low == up

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,6 +136,17 @@ const rtol = Dict(Float32 => 10 * sqrt(eps(Float32)),
         end
     end
 
+    @testset "Complement coordinates (quad_cmpl)" begin
+        f_cmpl(x, bmx, xma) = 1 / sqrt(bmx * xma)
+
+        # Default interval [-1, 1]
+        @test isapprox(quad_cmpl(f_cmpl, -1.0, 1.0; tol=1e-12), π, atol=1e-12)
+
+        # General interval [a, b]
+        a, b = -2.5, 3.25
+        @test isapprox(quad_cmpl(f_cmpl, a, b; tol=1e-12), π, atol=1e-12)
+    end
+
     @testset "Logarithmic singularities T=$T" for T in Types
         exact = 2 * log(T(2)) - 2
         f1(x) = log(1 - x)


### PR DESCRIPTION
This PR addresses the quad_cmpl part of #4.

What was fixed
- Corrected complementary argument semantics to f(x, b-x, x-a) (so on [-1,1]: f(x, 1-x, 1+x)).
- Fixed endpoint-tail truncation in complementary adaptive integration (use weight-based t window).
- Improved numerical stability of ordinate_complement for large t.
- Updated README/API docs accordingly.
- Added regression tests for quad_cmpl on [-1,1] and general [a,b].

Result
The README-style example for f(x, omx, opx) = 1 / sqrt(omx * opx) now returns π to machine precision.

Refs #4