### PR TITLE
Improve quadrature tests (1D/3D families), split test suite, and fix bounded 3D plane mapping

### DIFF
--- a/src/integrate3D.jl
+++ b/src/integrate3D.jl
@@ -161,6 +161,8 @@ function integrate3D(f::S, low::SVector{3,T}, up::SVector{3,T},
             wi = w[i]
             dx = Δx * x[i]
             xp, xm = x₀ + dx, x₀ - dx
+            dy_i = Δy * x[i]
+            yp_i, ym_i = y₀ + dy_i, y₀ - dy_i
 
             for j in eachindex(x)
                 wj = w[j]
@@ -168,11 +170,11 @@ function integrate3D(f::S, low::SVector{3,T}, up::SVector{3,T},
                 dy = Δy * x[j]
                 yp, ym = y₀ + dy, y₀ - dy
                 dz_j = Δz * x[j]
-                dx_j = Δx * x[j]
+                zp_j, zm_j = z₀ + dz_j, z₀ - dz_j
 
                 plane_sum = (f(xp, yp, z₀) + f(xm, yp, z₀) + f(xp, ym, z₀) + f(xm, ym, z₀)) +
-                            (f(xp, y₀, z₀ + dz_j) + f(xm, y₀, z₀ + dz_j) + f(xp, y₀, z₀ - dz_j) + f(xm, y₀, z₀ - dz_j)) +
-                            (f(x₀, yp, z₀ + dx_j) + f(x₀, ym, z₀ + dx_j) + f(x₀, yp, z₀ - dx_j) + f(x₀, ym, z₀ - dx_j))
+                            (f(xp, y₀, zp_j) + f(xm, y₀, zp_j) + f(xp, y₀, zm_j) + f(xm, y₀, zm_j)) +
+                            (f(x₀, yp_i, zp_j) + f(x₀, ym_i, zp_j) + f(x₀, yp_i, zm_j) + f(x₀, ym_i, zm_j))
 
                 total_sum += wiwj * w₀ * plane_sum
 
@@ -228,6 +230,8 @@ function integrate3D_avx(f::S, low::SVector{3,T}, up::SVector{3,T},
             wi = w[i]
             dx = Δx * x[i]
             xp, xm = x₀ + dx, x₀ - dx
+            dy_i = Δy * x[i]
+            yp_i, ym_i = y₀ + dy_i, y₀ - dy_i
 
             for j in eachindex(x)
                 wj = w[j]
@@ -235,11 +239,11 @@ function integrate3D_avx(f::S, low::SVector{3,T}, up::SVector{3,T},
                 dy = Δy * x[j]
                 yp, ym = y₀ + dy, y₀ - dy
                 dz_j = Δz * x[j]
-                dx_j = Δx * x[j]
+                zp_j, zm_j = z₀ + dz_j, z₀ - dz_j
 
                 plane_sum = (f(xp, yp, z₀) + f(xm, yp, z₀) + f(xp, ym, z₀) + f(xm, ym, z₀)) +
-                            (f(xp, y₀, z₀ + dz_j) + f(xm, y₀, z₀ + dz_j) + f(xp, y₀, z₀ - dz_j) + f(xm, y₀, z₀ - dz_j)) +
-                            (f(x₀, yp, z₀ + dx_j) + f(x₀, ym, z₀ + dx_j) + f(x₀, yp, z₀ - dx_j) + f(x₀, ym, z₀ - dx_j))
+                            (f(xp, y₀, zp_j) + f(xm, y₀, zp_j) + f(xp, y₀, zm_j) + f(xm, y₀, zm_j)) +
+                            (f(x₀, yp_i, zp_j) + f(x₀, ym_i, zp_j) + f(x₀, yp_i, zm_j) + f(x₀, ym_i, zm_j))
 
                 total_sum += wiwj * w₀ * plane_sum
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,0 +1,57 @@
+@testset "Core helper identities and constructors" begin
+    t = 1.75
+    x_t = FastTanhSinhQuadrature.ordinate(t)
+    x_mt = FastTanhSinhQuadrature.ordinate(-t)
+    @test isapprox(x_mt, -x_t, atol=0.0, rtol=10 * eps(Float64))
+
+    w_t = FastTanhSinhQuadrature.weight(t)
+    w_mt = FastTanhSinhQuadrature.weight(-t)
+    @test isapprox(w_mt, w_t, atol=0.0, rtol=10 * eps(Float64))
+
+    c_t = FastTanhSinhQuadrature.ordinate_complement(t)
+    @test isapprox(c_t, 1 - abs(x_t), atol=1e-16, rtol=1e-12)
+
+    @test isapprox(FastTanhSinhQuadrature.inv_ordinate(x_t), t, atol=1e-13)
+
+    # Branch guards near saturation/underflow
+    @test FastTanhSinhQuadrature.ordinate(50.0) == prevfloat(1.0)
+    @test FastTanhSinhQuadrature.ordinate(-50.0) == -prevfloat(1.0)
+    @test FastTanhSinhQuadrature.weight(8.0) == 0.0
+
+    tx = FastTanhSinhQuadrature.t_x_max(Float64)
+    tw = FastTanhSinhQuadrature.t_w_max(Float64, 3)
+    @test FastTanhSinhQuadrature.tmax(Float64, 3) == min(tx, tw)
+
+    xodd, wodd, hodd = tanhsinh(Float64, 79)
+    @test length(xodd) == 39
+    @test length(wodd) == 39
+    @test hodd > 0
+
+    xval, wval, hval = tanhsinh(Float64, Val(11))
+    @test xval isa SVector{5,Float64}
+    @test wval isa SVector{5,Float64}
+    @test hval > 0
+
+    xval_even, wval_even, hval_even = tanhsinh(Float64, Val(10))
+    @test xval_even isa SVector{5,Float64}
+    @test wval_even isa SVector{5,Float64}
+    @test hval_even > 0
+
+    xdef, wdef, hdef = tanhsinh(80)
+    x64, w64, h64 = tanhsinh(Float64, 80)
+    @test xdef == x64
+    @test wdef == w64
+    @test hdef == h64
+
+    xopt, wopt, hopt = FastTanhSinhQuadrature.tanhsinh_opt(Float64, 80)
+    @test !isempty(xopt)
+    @test length(xopt) == length(wopt)
+    @test hopt > 0
+    xopt_odd, wopt_odd, hopt_odd = FastTanhSinhQuadrature.tanhsinh_opt(Float64, 81)
+    @test !isempty(xopt_odd)
+    @test length(xopt_odd) == length(wopt_odd)
+    @test hopt_odd > 0
+    @test FastTanhSinhQuadrature.hopt(Float64, 80) > 0
+    @test FastTanhSinhQuadrature.hmax(Float64, 80) > 0
+    @test FastTanhSinhQuadrature.hmax(Float64, 81) > 0
+end

--- a/test/dispatch.jl
+++ b/test/dispatch.jl
@@ -1,0 +1,50 @@
+@testset "quad_split polynomial consistency in 2D" begin
+    low = SVector(-1.0, -1.0)
+    up = SVector(1.0, 1.0)
+    c = SVector(0.0, 0.0)
+    f2(x, y) = x^2 + y^2
+    # ∫∫ (x²+y²) dx dy on [-1,1]² = 8/3.
+    @test isapprox(quad_split(f2, c, low, up; tol=1e-9, max_levels=8), 8 / 3, atol=1e-9)
+end
+
+@testset "Adaptive base-level path (max_levels=0)" begin
+    low2 = SVector(-1.0, -1.0)
+    up2 = SVector(1.0, 1.0)
+    low3 = SVector(-1.0, -1.0, -1.0)
+    up3 = SVector(1.0, 1.0, 1.0)
+
+    val1 = adaptive_integrate_1D(Float64, exp, 0.0, 1.0; max_levels=0)
+    val2 = adaptive_integrate_2D(Float64, f2_const, low2, up2; max_levels=0)
+    val3 = adaptive_integrate_3D(Float64, f3_const, low3, up3; max_levels=0)
+    valc = adaptive_integrate_1D_cmpl(Float64, (x, bmx, xma) -> 1 / sqrt(bmx * xma), -1.0, 1.0; max_levels=0)
+
+    @test isfinite(val1) && val1 > 0
+    @test isfinite(val2) && val2 > 0
+    @test isfinite(val3) && val3 > 0
+    @test isfinite(valc) && valc > 0
+end
+
+@testset "Edge Cases and Safety" begin
+    # Zero range
+    @test quad(x -> x, 1.0, 1.0) == 0.0
+    # Flipped
+    @test isapprox(quad(x -> x, 1.0, 0.0), -0.5, atol=1e-12)
+
+    # 2D/3D through AbstractVector dispatch
+    @test isapprox(quad((x, y) -> x + y, [0.0, 0.0], [1.0, 2.0]), 3.0, atol=1e-10)
+    @test isapprox(quad((x, y, z) -> 1.0, [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]), 1.0, atol=1e-12)
+    @test_throws ErrorException quad((args...) -> sum(args), zeros(4), ones(4))
+
+    # Any degenerate dimension should return zero.
+    @test quad((x, y) -> x + y, SVector(0.0, 1.0), SVector(0.0, 2.0)) == 0.0
+    @test quad((x, y, z) -> x + y + z, SVector(0.0, 1.0, -2.0), SVector(0.0, 2.0, 4.0)) == 0.0
+
+    # Odd number of flipped bounds => negative orientation.
+    @test isapprox(quad((x, y) -> 1.0, SVector(1.0, -1.0), SVector(0.0, 2.0)), -3.0, atol=1e-12)
+    @test isapprox(quad((x, y, z) -> 1.0, SVector(1.0, -1.0, -1.0), SVector(0.0, 2.0, 3.0)), -12.0, atol=1e-12)
+    @test isapprox(quad((x, y, z) -> 1.0, SVector(0.0, 2.0, 3.0), SVector(1.0, -1.0, -1.0)), 12.0, atol=1e-12)
+
+    f_cmpl(x, bmx, xma) = 1 / sqrt(bmx * xma)
+    @test quad_cmpl(f_cmpl, 1.0, 1.0) == 0.0
+    @test isapprox(quad_cmpl(f_cmpl, 1.0, -1.0; tol=1e-12), -π, atol=1e-12)
+end

--- a/test/families_1d.jl
+++ b/test/families_1d.jl
@@ -1,0 +1,27 @@
+@testset "1D mathematical families" begin
+    exact_poly = 9 / 7
+    exact_rat = 2 * atan(5.0) / 5
+    exact_exp = exp(1.0) - exp(-1.0)
+    exact_log = 2 * log(2.0) - 2
+
+    poly(x) = x^6 - 2x^3 + 0.5
+    rat(x) = 1 / (1 + 25x^2)
+    log_sing(x) = log(1 - x)
+    cmpl_sing(x, bmx, xma) = 1 / sqrt(bmx * xma)
+
+    x, w, h = tanhsinh(Float64, 120)
+    @test isapprox(integrate1D(poly, x, w, h), exact_poly, atol=1e-12)
+    @test isapprox(integrate1D(rat, x, w, h), exact_rat, atol=1e-6)
+    @test isapprox(integrate1D(exp, x, w, h), exact_exp, atol=1e-12)
+    @test isapprox(integrate1D(log_sing, x, w, h), exact_log, atol=1e-11)
+
+    @test isapprox(integrate1D(Float64, poly, 120), exact_poly, atol=1e-12)
+    @test isapprox(integrate1D(poly, 120), exact_poly, atol=1e-12)
+    @test isapprox(FastTanhSinhQuadrature.integrate1D_cmpl(Float64, cmpl_sing, 120), π, atol=5e-8)
+
+    @test isapprox(quad(poly, -1.0, 1.0; tol=1e-12), exact_poly, atol=1e-12)
+    @test isapprox(quad(rat, -1.0, 1.0; tol=1e-12), exact_rat, atol=1e-12)
+    @test isapprox(quad(exp, -1.0, 1.0; tol=1e-12), exact_exp, atol=1e-12)
+    @test isapprox(quad(log_sing, -1.0, 1.0; tol=1e-12), exact_log, atol=1e-11)
+    @test isapprox(quad_cmpl(cmpl_sing, -1.0, 1.0; tol=1e-12), π, atol=1e-12)
+end

--- a/test/families_3d.jl
+++ b/test/families_3d.jl
@@ -1,0 +1,77 @@
+@testset "3D fixed-grid and AVX on [-1,1], T=$T" for T in (Float32, Float64)
+    n = T == Float32 ? 30 : 60
+    x, w, h = tanhsinh(T, n)
+    ψ = integrate3D(f3_const, x, w, h)
+    odd = integrate3D(f3_xyz, x, w, h)
+    even = integrate3D(f3_x2y2z2, x, w, h)
+
+    @test isapprox(ψ, T(8), atol=T == Float32 ? T(2e-5) : T(1e-12))
+    @test isapprox(odd, zero(T), atol=T == Float32 ? T(2e-6) : T(1e-14))
+    @test isapprox(even, T(8) / T(27), atol=T == Float32 ? T(2e-6) : T(1e-13))
+
+    run_avx_checks() do
+        ψ_avx = integrate3D_avx(f3_const, x, w, h)
+        odd_avx = integrate3D_avx(f3_xyz, x, w, h)
+        even_avx = integrate3D_avx(f3_x2y2z2, x, w, h)
+        @test isapprox(ψ_avx, ψ, atol=T == Float32 ? T(2e-5) : T(1e-12))
+        @test isapprox(odd_avx, odd, atol=T == Float32 ? T(2e-6) : T(1e-14))
+        @test isapprox(even_avx, even, atol=T == Float32 ? T(2e-6) : T(1e-13))
+    end
+end
+
+@testset "3D anisotropic box regression (fixed-grid + AVX)" begin
+    T = Float64
+    low = SVector{3,T}(-2.0, -1.0, 0.0)
+    up = SVector{3,T}(3.0, 2.0, 4.0)
+    x, w, h = tanhsinh(T, 80)
+
+    f_poly(x, y, z) = x^2 + 2y + 3z^2
+    exact_poly =
+        integral_monomial_3d(low, up, 2, 0, 0) +
+        2 * integral_monomial_3d(low, up, 0, 1, 0) +
+        3 * integral_monomial_3d(low, up, 0, 0, 2)
+
+    val = integrate3D(f_poly, low, up, x, w, h)
+    @test isapprox(val, exact_poly, atol=1e-10)
+
+    run_avx_checks() do
+        val_avx = integrate3D_avx(f_poly, low, up, x, w, h)
+        @test isapprox(val_avx, exact_poly, atol=1e-10)
+        @test isapprox(val_avx, val, atol=1e-10)
+    end
+
+    # Simple monomial catch for axis/plane bookkeeping: ∫ z² dV on anisotropic box.
+    f_z2(x, y, z) = z^2
+    exact_z2 = integral_monomial_3d(low, up, 0, 0, 2)
+    @test isapprox(integrate3D(f_z2, low, up, x, w, h), exact_z2, atol=1e-10)
+end
+
+@testset "3D mathematical families (adaptive quad)" begin
+    low = SVector(-1.0, -1.0, -1.0)
+    up = SVector(1.0, 1.0, 1.0)
+
+    exact_rat = (2 * atan(5.0) / 5) * (2 * atan(4.0) / 4) * (2 * atan(3.0) / 3)
+    exact_exp = (exp(1.0) - exp(-1.0))^3
+    exact_log_1d = 2 * log(2.0) - 2
+    exact_log = exact_log_1d^3
+    exact_sing = π^3
+
+    rat3(x, y, z) = 1 / ((1 + 25x^2) * (1 + 16y^2) * (1 + 9z^2))
+    exp3(x, y, z) = exp(x + y + z)
+    log3(x, y, z) = log(1 - x) * log(1 - y) * log(1 - z)
+    sing3(x, y, z) = 1 / sqrt((1 - x^2) * (1 - y^2) * (1 - z^2))
+
+    @test isapprox(quad(rat3, low, up; tol=1e-9, max_levels=8), exact_rat, atol=1e-9)
+    @test isapprox(quad(exp3, low, up; tol=1e-9, max_levels=8), exact_exp, atol=1e-9)
+    @test isapprox(quad(log3, low, up; tol=1e-8, max_levels=8), exact_log, atol=5e-9)
+    @test isapprox(quad(sing3, low, up; tol=1e-8, max_levels=8), exact_sing, atol=2e-7)
+end
+
+@testset "3D split-domain singular family" begin
+    low = SVector(-1.0, -1.0, -1.0)
+    up = SVector(1.0, 1.0, 1.0)
+    c = SVector(0.0, 0.0, 0.0)
+    f_abs3(x, y, z) = 1 / sqrt(abs(x * y * z))
+    # Separable exact value: (∫_{-1}^1 |x|^{-1/2} dx)^3 = 4^3 = 64.
+    @test isapprox(quad_split(f_abs3, c, low, up; tol=1e-6, max_levels=6), 64.0, atol=3e-6)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,26 @@ function run_avx_checks(f::Function)
     end
 end
 
+@inline integral_monomial_1d(low::T, up::T, p::Int) where {T<:Real} =
+    (up^(p + 1) - low^(p + 1)) / T(p + 1)
+
+@inline integral_monomial_3d(low::SVector{3,T}, up::SVector{3,T},
+    px::Int, py::Int, pz::Int) where {T<:Real} =
+    integral_monomial_1d(low[1], up[1], px) *
+    integral_monomial_1d(low[2], up[2], py) *
+    integral_monomial_1d(low[3], up[3], pz)
+
+f2_const(x, y) = one(x)
+f2_xy(x, y) = x * y
+f2_x2y2(x, y) = x^2 * y^2
+
+f3_const(x, y, z) = one(x)
+f3_xyz(x, y, z) = x * y * z
+f3_x2y2z2(x, y, z) = x^2 * y^2 * z^2
+
 @testset "FastTanhSinhQuadrature.jl" begin
+
+    include("core.jl")
 
     @testset "Basic integration T=$T" for T in Types
         f0(x) = one(T)
@@ -110,6 +129,8 @@ end
         @test isapprox(F01 + F11, F1, rtol=rtol[T])
     end
 
+    include("families_1d.jl")
+
     @testset "2D polynomials for [-1, 1], T=$T" for T in Types
         n = T == Float32 ? 40 : 80
         x, w, h = tanhsinh(T, n)
@@ -136,6 +157,8 @@ end
         # Test quad helper 2D flip
         @test isapprox(quad(ψ, up, low), 4one(T); atol=tol_check, rtol=sqrt(eps(T)))
     end
+
+    include("families_3d.jl")
 
     @testset "Adaptive integration 1D" begin
         f(x) = exp(x)
@@ -188,17 +211,10 @@ end
         # Exact is 4
         # Relax tolerance slightly for floating point noise near singularity
         @test isapprox(quad_split(f_abs, 0.0, -1.0, 1.0), 4.0, atol=1e-7)
+        @test isapprox(quad_split(f_abs, 0.0), 4.0, atol=1e-7)
     end
 
-    @testset "Edge Cases and Safety" begin
-        # Zero range
-        @test quad(x -> x, 1.0, 1.0) == 0.0
-        # Flipped
-        @test isapprox(quad(x -> x, 1.0, 0.0), -0.5, atol=1e-12)
-
-        # 3D
-        @test isapprox(quad((x, y, z) -> 1.0, [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]), 1.0, atol=1e-12)
-    end
+    include("dispatch.jl")
 end
 
 # Aqua.jl quality assurance tests


### PR DESCRIPTION
## Summary
This PR significantly strengthens mathematical test coverage for `FastTanhSinhQuadrature.jl`, especially in 3D, and reorganizes new tests into focused files for maintainability.

It also fixes a bug in bounded 3D fixed-grid integration (`integrate3D` / `integrate3D_avx`) where plane-term coordinate mapping was incorrect on anisotropic boxes.

## Why
Coverage and test depth were too low for core numerical paths.  
This adds rigorous, analytic tests across multiple function families and edge cases so helper logic, dispatch paths, and 3D kernels are validated mathematically.

## Changes

### 1) Test suite refactor
Split newly added tests into dedicated files:
- `test/core.jl`
- `test/families_1d.jl`
- `test/families_3d.jl`
- `test/dispatch.jl`

`test/runtests.jl` now includes these files.

### 2) New rigorous mathematical tests
Added/expanded tests for:
- **Core/helper identities**:
  - ordinate odd symmetry
  - weight even symmetry
  - complement identity
  - inverse map consistency
  - saturation/underflow guard branches
  - odd/even constructor paths (`Int`, `Val`, opt/max spacing helpers)
- **1D families**:
  - polynomials
  - rational (`atan` closed form)
  - exponential
  - logarithmic endpoint singularity
  - complement-coordinate endpoint singularity
- **3D families**:
  - fixed-grid + AVX on `[-1,1]^3` (constant, odd cancellation, even polynomial)
  - anisotropic-box polynomial regression with analytic exact integrals
  - adaptive `quad` families: rational, exp, log, algebraic endpoint singular
  - split-domain internal singularity (`quad_split`) in 3D
- **Dispatch / safety / edge cases**:
  - vector and `SVector` dispatch paths
  - degenerate-dimension zero-volume behavior
  - orientation/sign behavior under flipped bounds
  - unsupported dimension error path
  - `quad_cmpl` zero/flip behavior
  - adaptive base-level return (`max_levels=0`)

### 3) 3D integration bug fix
In bounded 3D fixed-grid kernels:
- corrected plane contribution coordinate mapping in:
  - `integrate3D(f, low, up, x, w, h)`
  - `integrate3D_avx(f, low, up, x, w, h)`

This removes incorrect results on anisotropic domains and aligns fixed-grid results with adaptive `quad`.

## Validation
- `Pkg.test()` passes (including Aqua)
- Local coverage run with `--code-coverage=user` shows full executable-line coverage in `src` in this environment.
